### PR TITLE
Only static link gnutls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         name: Publish the wget binary
         runs-on: ubuntu-latest
         needs: build
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: startsWith(github.ref, 'refs/tags/v')
         steps:
             - name: Fetch the built binary
               uses: actions/download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
         tags:
             - '*'
         branches:
-            - '*'
+            - main
+    pull_request:
 jobs:
     build:
         name: Build the wget binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
     push:
         tags:
             - '*'
+        branches:
+            - '*'
 jobs:
     build:
         name: Build the wget binary
@@ -23,6 +25,7 @@ jobs:
         name: Publish the wget binary
         runs-on: ubuntu-latest
         needs: build
+        if: ${{ github.ref == 'refs/heads/main' }}
         steps:
             - name: Fetch the built binary
               uses: actions/download-artifact@v2

--- a/build
+++ b/build
@@ -45,7 +45,7 @@ rm nettle.tar.gz
     --disable-shared \
     --disable-documentation \
     --disable-assembler
-make
+make -j $(nproc)
 make install
 
 popd
@@ -69,7 +69,7 @@ rm gnutls.tar.xz
     --with-included-libtasn1 \
     --with-included-unistring \
     --without-p11-kit
-make
+make -j $(nproc)
 make install
 
 popd
@@ -84,11 +84,11 @@ fetch https://ftp.gnu.org/gnu/wget/wget-1.21.1.tar.gz wget.tar.gz \
 tar --strip-components=1 -zxf wget.tar.gz
 rm wget.tar.gz
 
-export GNUTLS_LIBS="-L$SYSROOT/usr/lib -static -lgnutls -pthread -latomic -lhogweed -lnettle"
+export GNUTLS_LIBS="-L$SYSROOT/usr/lib -Wl,-Bstatic -lgnutls -Wl,-Bdynamic -pthread -latomic -lhogweed -lnettle"
 ./configure \
     --prefix="$SYSROOT/usr" \
     --host="$CHOST"
-make
+make -j $(nproc)
 
 popd
 mv wget-build/src/wget .


### PR DESCRIPTION
This prevents a crash on firmware versions 3.6+.
The NSS functions in glibc don't play nice with static linking.

Resolves https://github.com/toltec-dev/toltec/issues/731